### PR TITLE
Add Conversion for Memory to Long

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,4 +25,4 @@ deployMinikubeRpArguments ++= Vector(
 
 deployMinikubeAkkaClusterBootstrapContactPoints := 3
 
-memory := 512 * 1024 * 1024
+memory := 512L * 1024 * 1024


### PR DESCRIPTION
The `memory` key is defined with type Long, and without an explicit conversion, the setting is not being properly set.